### PR TITLE
Custom  tags and feed items in subject

### DIFF
--- a/EventListener/EmailSubscriber.php
+++ b/EventListener/EmailSubscriber.php
@@ -37,5 +37,11 @@ class EmailSubscriber extends CommonSubscriber
         $content = $parser->getContent();
 
         $event->setContent($content);
+
+        // Also replace feed items in the subject
+        $content = $event->getSubject();
+        $parser  = new Parser($content);
+        $content = $parser->getContent();
+        $event->setSubject($content);
     }
 }

--- a/Parser/ItemTag.php
+++ b/Parser/ItemTag.php
@@ -83,6 +83,12 @@ class ItemTag
                     $value = $enclosure->get_link();
                 }
                 break;
+            default:
+                $custTag = $feedItem->get_item_tags('',$this->tag);
+                if(!empty($custTag)) {
+                    $value = $custTag[0]['data'];
+                }
+                break;
         }
 
         return $value;

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The Mautic RssToEmailBundle is a Mautic plugin that allows you to generate e-mai
 Send out an e-mail with for example to latest posts of your blog.
 
 ### Compatibility
-This plugin has been tested with v2.13.1 of Mautic.
+This plugin has been tested with v2.14.1 of Mautic.
 
 ### Features
  * Set the number of posts you want to display


### PR DESCRIPTION
This merge requests adds two small features:

1. The ability to use custom rss tags for items, i.e. `{feeditem:mytag}`
2. It also replaces the tags in the subject of the email, so that the subject can also be based on the RSS feed content

Furthermore, I verified that the plugin works fine with the latest Mautic release.