### PR TITLE
Allow lead fields in url

### DIFF
--- a/EventListener/EmailSubscriber.php
+++ b/EventListener/EmailSubscriber.php
@@ -32,15 +32,14 @@ class EmailSubscriber extends CommonSubscriber
     {
         // // Get content
         $content = $event->getContent();
-
-        $parser  = new Parser($content);
+        $parser  = new Parser($content, $event);
         $content = $parser->getContent();
 
         $event->setContent($content);
 
         // Also replace feed items in the subject
         $content = $event->getSubject();
-        $parser  = new Parser($content);
+        $parser  = new Parser($content, $event);
         $content = $parser->getContent();
         $event->setSubject($content);
     }

--- a/Parser/Parser.php
+++ b/Parser/Parser.php
@@ -10,23 +10,23 @@ class Parser
 
     protected $content = null;
 
-    public function __construct($content)
+    public function __construct($content, $event)
     {
-        preg_match_all('/{feed([^}]*)}(.*){\/feed}/msU', $content, $matches);
+        preg_match_all('/{feed((?:[^{}]|{[^}]*})*)}(.*){\/feed}/msU', $content, $matches);
 
         if (!empty($matches[0])) {
             foreach ($matches[0] as $key => $feedWrapper) {
                 $this->parseParams($matches[1][$key]);
 
                 $feedContent = $matches[2][$key];
-                $feedUrl     = $this->getParam('url');
+                $feedUrl     = str_replace(array_keys($event->getTokens()), $event->getTokens(), $this->getParam('url'));
 
                 if (!$this->validateFeedUrl($feedUrl)) {
                     $content = str_replace($feedWrapper, "Error: URL ({$feedUrl}) empty or not valid", $content);
                     continue;
                 }
 
-                $feed = new Feed($this->getParam('url'));
+                $feed = new Feed($feedUrl);
 
                 if (is_null($feed->getFeed()->error())) {
                     $feedParser        = new FeedParser($feedContent, $feed);

--- a/Parser/Parser.php
+++ b/Parser/Parser.php
@@ -3,6 +3,7 @@ namespace MauticPlugin\MauticRssToEmailBundle\Parser;
 
 use MauticPlugin\MauticRssToEmailBundle\Feed\Feed;
 use MauticPlugin\MauticRssToEmailBundle\Traits\ParamsTrait;
+use Mautic\LeadBundle\Helper\TokenHelper;
 
 class Parser
 {
@@ -19,8 +20,7 @@ class Parser
                 $this->parseParams($matches[1][$key]);
 
                 $feedContent = $matches[2][$key];
-                $feedUrl     = str_replace(array_keys($event->getTokens()), $event->getTokens(), $this->getParam('url'));
-
+                $feedUrl = TokenHelper::findLeadTokens($this->getParam('url'), $event->getLead(), true);
                 if (!$this->validateFeedUrl($feedUrl)) {
                     $content = str_replace($feedWrapper, "Error: URL ({$feedUrl}) empty or not valid", $content);
                     continue;


### PR DESCRIPTION
As title, this replaces leadfields in the url so that we can customize an RSS feed to a user by putting its e-mailaddress in the url, e.g.:

```
{feed url="http://mywebsite.com/rss/users/{leadfield=email}"}
```